### PR TITLE
mutate configuration state

### DIFF
--- a/infra/main.go
+++ b/infra/main.go
@@ -11,7 +11,10 @@ func main() {
 
 	pulumi.Run(func(ctx *pulumi.Context) error {
 
-		validConfig, err := vpc.Validate(ctx)
+		params := &vpc.Parameters{}
+
+		validConfig, err := params.Validate(ctx)
+
 		if err != nil {
 			return fmt.Errorf("failed to load configurations: %w", err)
 		}

--- a/infra/vpc/vpc.go
+++ b/infra/vpc/vpc.go
@@ -13,16 +13,15 @@ type Parameters struct {
 	Name, Cidr, Env, VpcTagKey, PublicSubnetCirdr, PrivateSubnetCirdr string
 }
 
-func Validate(ctx *pulumi.Context, opts ...Parameters) (*Parameters, error) {
+func (p *Parameters) Validate(ctx *pulumi.Context, opts ...Parameters) (*Parameters, error) {
 	conf := config.New(ctx, "")
-	p := Parameters{
-		Name:               conf.Require("vpcName"),
-		Cidr:               conf.Require("vpcCIDR"),
-		Env:                ctx.Stack(),
-		VpcTagKey:          "Name",
-		PublicSubnetCirdr:  conf.Require("publicSubnetCIDR"),
-		PrivateSubnetCirdr: conf.Require("privateSubnetCIDR"),
-	}
+
+	p.Name = conf.Require("vpcName")
+	p.Cidr = conf.Require("vpcCIDR")
+	p.Env = ctx.Stack()
+	p.VpcTagKey = "Name"
+	p.PublicSubnetCirdr = conf.Require("publicSubnetCIDR")
+	p.PrivateSubnetCirdr = conf.Require("privateSubnetCIDR")
 
 	switch {
 	case p.Name == "":
@@ -38,7 +37,7 @@ func Validate(ctx *pulumi.Context, opts ...Parameters) (*Parameters, error) {
 		return nil, fmt.Errorf("privateSubnetCIDR is required in pulumi config")
 
 	}
-	return &p, nil
+	return p, nil
 }
 
 func CreateSubnets(ctx *pulumi.Context, vpc *ec2.Vpc, p *Parameters) ([]*ec2.Subnet, error) {


### PR DESCRIPTION
Changes made (Fix previous)
Keep the Configuration State (Mutate) in memory after loading so that the state can be called without reloading

Previous
Continuous Loading Configuration for each calls to Validate() function

